### PR TITLE
Hi there. I've just filled an issue (#5) and corresponding code to provide required feature support. I hope you can merge it.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -48,7 +48,7 @@ object Play2MorphiaPluginBuild extends Build {
 
   object BuildSettings {
     val buildOrganization = "leodagdag"
-    val buildVersion      = "0.0.5"
+    val buildVersion      = "0.0.6"
     val buildScalaVersion = "2.9.1"
     val buildSbtVersion   = "0.11.2"
     val buildSettings = Defaults.defaultSettings ++ Seq (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline
 addSbtPlugin("com.jsuereth" % "sbt-git-plugin" % "0.4")
 
 //SBT Scala format
-addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.3.0")
+addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.3.1")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 

--- a/src/main/java/leodagdag/play2morphia/MorphiaPlugin.java
+++ b/src/main/java/leodagdag/play2morphia/MorphiaPlugin.java
@@ -73,15 +73,29 @@ public class MorphiaPlugin extends Plugin {
             // Configure validator
             MorphiaValidation morphiaValidation = new MorphiaValidation();
             morphiaValidation.applyTo(morphia);
+
+			//Check if credentials parameters are present
+			String username = morphiaConf.getString(ConfigKey.DB_USERNAME.getKey());
+			String password = morphiaConf.getString(ConfigKey.DB_PASSWORD.getKey());
+						
+			if(StringUtils.isNotBlank(username) ^ StringUtils.isNotBlank(password)){
+				throw morphiaConf.reportError(ConfigKey.DB_NAME.getKey(), "Missing username or password", null);
+			}
+			
             // Create datastore
-            ds = morphia.createDatastore(mongo, dbName);
+			if(StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)){
+				ds = morphia.createDatastore(mongo, dbName, username, password.toCharArray());
+			} else {
+            	ds = morphia.createDatastore(mongo, dbName);				
+			}
+
 
             MorphiaLogger.debug("Datastore [%s] created", dbName);
             // Create GridFS
             String uploadCollection = morphiaConf.getString(ConfigKey.COLLECTION_UPLOADS.getKey());
             if (StringUtils.isBlank(dbName)) {
                 uploadCollection = "uploads";
-                MorphiaLogger.warn("Missing Morphia configuration key [%s]. Use defqult value instead [%s]", ConfigKey.COLLECTION_UPLOADS, "uploads");
+                MorphiaLogger.warn("Missing Morphia configuration key [%s]. Use default value instead [%s]", ConfigKey.COLLECTION_UPLOADS, "uploads");
             }
             gridfs = new GridFS(ds.getDB(), uploadCollection);
             MorphiaLogger.debug("GridFS created", "");

--- a/src/main/java/leodagdag/play2morphia/utils/ConfigKey.java
+++ b/src/main/java/leodagdag/play2morphia/utils/ConfigKey.java
@@ -5,6 +5,8 @@ public enum ConfigKey {
 	DB_HOST("db.host"), //
 	DB_PORT("db.port"), //
 	DB_NAME("db.name"), //
+	DB_USERNAME("db.username"), //
+	DB_PASSWORD("db.password"), //
 	ID_TYPE("id.type"), //
 	DEFAULT_WRITE_CONCERN("defaultWriteConcern"), //
 	COLLECTION_UPLOADS("collection.upload"), //


### PR DESCRIPTION
add support through inclusion of 2 new parameters: db.username, db.password.
These parameters were added to ConfigKey, and are used by plugin in case both are declared. Otherwise an exception is thrown.

changed couple versions as well
sbt.version 0.11.3
sbtscalariform to 0.3.1
this was done mainly because couldn't find previous versions in repository

also bumped plugin version to 0.0.6 as per authentication support
